### PR TITLE
Updated Cve.json

### DIFF
--- a/release-notes/timeline/2024/01/cve.json
+++ b/release-notes/timeline/2024/01/cve.json
@@ -222,7 +222,7 @@
       "fixed": "7.0.15",
       "release": "7.0",
       "commits": [
-        "8b3f5333523ac4f3a7520c5c9261ac6f2a2b6b23"
+        "360f1564385745dd9e9acc53e697f8e63ff41126"
       ]
     },
     {
@@ -334,6 +334,13 @@
       "org": "dotnet",
       "url": "https://github.com/dotnet/aspnetcore/commit/00f7c0edf759ec4fa22094a1571b1b1530ffe183.diff"
     },
+    "360f1564385745dd9e9acc53e697f8e63ff41126": {
+      "repo": "aspnetcore",
+      "branch": "release/7.0",
+      "hash": "360f1564385745dd9e9acc53e697f8e63ff41126",
+      "org": "dotnet",
+      "url": "https://github.com/dotnet/aspnetcore/commit/360f1564385745dd9e9acc53e697f8e63ff41126.diff"
+    },
     "8b3f5333523ac4f3a7520c5c9261ac6f2a2b6b23": {
       "repo": "aspnetcore",
       "branch": "release/8.0",
@@ -406,6 +413,7 @@
     ],
     "CVE-2024-21319": [
       "00f7c0edf759ec4fa22094a1571b1b1530ffe183",
+      "360f1564385745dd9e9acc53e697f8e63ff41126",
       "8b3f5333523ac4f3a7520c5c9261ac6f2a2b6b23"
     ]
   }

--- a/release-notes/timeline/2024/11/cve.json
+++ b/release-notes/timeline/2024/11/cve.json
@@ -94,7 +94,7 @@
       "min_vulnerable": "9.0.0-preview.6.24327.7",
       "max_vulnerable": "9.0.0-rc.2.24473.5",
       "fixed": "9.0.0",
-      "release": "6.0",
+      "release": "9.0",
       "commits": [
         "d16f41ad8fded18bf82bca88df27967cc3365eb0"
       ]
@@ -160,9 +160,6 @@
     ]
   },
   "release_cves": {
-    "6.0": [
-      "CVE-2024-43498"
-    ],
     "9.0": [
       "CVE-2024-43498",
       "CVE-2024-43499"
@@ -170,7 +167,6 @@
   },
   "cve_releases": {
     "CVE-2024-43498": [
-      "6.0",
       "9.0"
     ],
     "CVE-2024-43499": [

--- a/release-notes/timeline/2025/04/cve.json
+++ b/release-notes/timeline/2025/04/cve.json
@@ -70,14 +70,14 @@
   "commits": {
     "d6605eb150c993dd8943e2c1a6875a93927c301a": {
       "repo": "aspnetcore",
-      "branch": "main",
+      "branch": "release/8.0",
       "hash": "d6605eb150c993dd8943e2c1a6875a93927c301a",
       "org": "dotnet",
       "url": "https://github.com/dotnet/aspnetcore/commit/d6605eb150c993dd8943e2c1a6875a93927c301a.diff"
     },
     "d5933a9d685c3a09566ec7c9ca818bd7ac2f08ad": {
       "repo": "aspnetcore",
-      "branch": "main",
+      "branch": "release/9.0",
       "hash": "d5933a9d685c3a09566ec7c9ca818bd7ac2f08ad",
       "org": "dotnet",
       "url": "https://github.com/dotnet/aspnetcore/commit/d5933a9d685c3a09566ec7c9ca818bd7ac2f08ad.diff"

--- a/release-notes/timeline/2025/05/cve.json
+++ b/release-notes/timeline/2025/05/cve.json
@@ -223,7 +223,7 @@
     },
     "391e16c3b5c49938029e20d9ee69c4d5bdf51c70": {
       "repo": "sdk",
-      "branch": "release/9.0.2xx",
+      "branch": "release/9.0.3xx",
       "hash": "391e16c3b5c49938029e20d9ee69c4d5bdf51c70",
       "org": "dotnet",
       "url": "https://github.com/dotnet/sdk/commit/391e16c3b5c49938029e20d9ee69c4d5bdf51c70.diff"

--- a/release-notes/timeline/2025/10/cve.json
+++ b/release-notes/timeline/2025/10/cve.json
@@ -6,7 +6,7 @@
       "id": "CVE-2025-55248",
       "problem": ".NET Information Disclosure Vulnerability",
       "description": [
-        "A MITM (man in the middle) attacker may prevent use of TLS between client and SMTP server, forcing client to send data over unencrypted connection."
+        "An AiTM (Attacker in the middle) attacker may prevent use of TLS between client and SMTP server, forcing client to send data over unencrypted connection."
       ],
       "cvss": {
         "version": "3.1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Fixes CVE metadata (commits, branches, release mappings) and a wording tweak across 2024–2025 timeline cve.json files.
> 
> - **Metadata corrections**:
>   - 2024/01 (`release-notes/timeline/2024/01/cve.json`):
>     - Update `CVE-2024-21319` ASP.NET Core 7.0 commit to `360f1564385745dd9e9acc53e697f8e63ff41126` and add its commit metadata; reflect in `cve_commits`.
>   - 2024/11 (`release-notes/timeline/2024/11/cve.json`):
>     - Set `CVE-2024-43498` release to `9.0`; remove `6.0` from `release_cves` and `cve_releases`.
>   - 2025/04 (`release-notes/timeline/2025/04/cve.json`):
>     - Correct commit branches: `d6605eb...` → `release/8.0`, `d5933a9...` → `release/9.0`.
>   - 2025/05 (`release-notes/timeline/2025/05/cve.json`):
>     - Update branch for `391e16c...` to `release/9.0.3xx`.
> - **Text/format tweaks**:
>   - 2025/10 (`release-notes/timeline/2025/10/cve.json`): Change "MITM" wording to "AiTM" in `CVE-2025-55248` description.
>   - Normalize file endings (ensure closing brace).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbb0eef556fa657dd05968b9609dc8d04b2f8029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->